### PR TITLE
Fix controlled/uncontrolled input warning in item modal

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -506,12 +506,12 @@ export default function ProjectDetails({ params }: { params: Promise<{ id: strin
               </div>
 
               {itemType === "attachment" ? (
-                <div>
+                <div key="attachment-input">
                   <label className="block text-sm font-medium text-gray-700 mb-1">File</label>
                   <input required type="file" onChange={e => setItemFile(e.target.files?.[0] || null)} className="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 transition" />
                 </div>
               ) : (
-                <div>
+                <div key="value-input">
                   <label className="block text-sm font-medium text-gray-700 mb-1">Valore</label>
                   <input required type={itemType === "number" ? "number" : itemType === "date" ? "date" : "text"} value={itemValue} onChange={e => setItemValue(e.target.value)} className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition" />
                 </div>


### PR DESCRIPTION
Fixes the React console error "A component is changing a controlled input to be uncontrolled" that happens when selecting "Allegato" from the dropdown. React was trying to reuse the same HTML input element for both the controlled text input and uncontrolled file input. Giving each wrapper a unique `key` forces React to treat them as distinct elements.

---
*PR created automatically by Jules for task [8049620177275123366](https://jules.google.com/task/8049620177275123366) started by @teoconnect*