### PR TITLE
fix: create missing api/uploads endpoint for attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ yarn-error.log*
 next-env.d.ts
 
 .env
-uploads/
+public/uploads/
 
 # dev.db
 dev.db-journal

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { writeFile } from "fs/promises";
+import path from "path";
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
+
+    if (!file) {
+      return NextResponse.json(
+        { error: "No file uploaded" },
+        { status: 400 }
+      );
+    }
+
+    const bytes = await file.arrayBuffer();
+    const buffer = Buffer.from(bytes);
+
+    // Save to public/uploads directory
+    const uploadDir = path.join(process.cwd(), "public", "uploads");
+    const filename = `${Date.now()}-${file.name}`;
+    const filepath = path.join(uploadDir, filename);
+
+    // Write file to public/uploads
+    await writeFile(filepath, buffer);
+
+    // Return the path relative to public directory for URL access
+    return NextResponse.json({ path: `/uploads/${filename}` }, { status: 201 });
+  } catch (error) {
+    console.error("Upload error:", error);
+    return NextResponse.json(
+      { error: "Failed to upload file" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Fixes the "Failed to upload file" error by adding the missing `/api/uploads` endpoint to handle attachments for task items. Uploaded files are now saved to `public/uploads` and properly returned.

---
*PR created automatically by Jules for task [4458365003833269996](https://jules.google.com/task/4458365003833269996) started by @teoconnect*