### PR TITLE
Fix SMTP config to support unauthenticated servers

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,18 +1,25 @@
 import nodemailer from 'nodemailer';
 
-const transporter = nodemailer.createTransport({
+import SMTPTransport from 'nodemailer/lib/smtp-transport';
+
+const transportConfig: SMTPTransport.Options = {
   host: process.env.SMTP_HOST,
   port: parseInt(process.env.SMTP_PORT || '587'),
   secure: parseInt(process.env.SMTP_PORT || '587') === 465, // true for 465, false for other ports
-  auth: {
+};
+
+if (process.env.SMTP_USER || process.env.SMTP_PASS) {
+  transportConfig.auth = {
     user: process.env.SMTP_USER,
     pass: process.env.SMTP_PASS,
-  },
-});
+  };
+}
+
+const transporter = nodemailer.createTransport(transportConfig);
 
 export const sendEmail = async (to: string, subject: string, html: string) => {
-  if (!process.env.SMTP_HOST || !process.env.SMTP_USER) {
-    console.warn('SMTP configurato parzialmente o mancante. Impossibile inviare la email.');
+  if (!process.env.SMTP_HOST) {
+    console.warn('SMTP_HOST mancante. Impossibile inviare la email.');
     return;
   }
 


### PR DESCRIPTION
Fix SMTP config to support unauthenticated servers

Updated `src/lib/email.ts` to only include the `auth` object in Nodemailer's transport configuration when `SMTP_USER` or `SMTP_PASS` are provided, allowing the application to connect to local open SMTP relays. Removed the strict requirement for `SMTP_USER` to be present when sending emails.

---
*PR created automatically by Jules for task [17844075830358689711](https://jules.google.com/task/17844075830358689711) started by @teoconnect*