### PR TITLE
Fix: Remove local network restriction in next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  allowedDevOrigins: ["127.0.0.1"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
This commit removes a custom configuration in `next.config.ts` that restricted development and local production access strictly to `127.0.0.1`. Removing this restriction enables the user to test the application from other devices connected to the same local area network (LAN), solving the "cross-origin" block they experienced when testing the production build locally.

---
*PR created automatically by Jules for task [15240640036326413882](https://jules.google.com/task/15240640036326413882) started by @teoconnect*