### PR TITLE
Fix: Disable secure flag for auth cookie in production

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
       value: token,
       httpOnly: true,
       path: "/",
-      secure: process.env.NODE_ENV === "production",
+      secure: false, // Forzato a false per permettere i test su rete locale HTTP
       maxAge: 60 * 60 * 24, // 1 day
     });
 


### PR DESCRIPTION
Forced the `secure` flag of the `auth-token` cookie to `false` in `src/app/api/auth/login/route.ts`. This allows the cookie to be stored and sent over HTTP, solving the issue of login loops when testing the production build on a local network without HTTPS. The HTTPS layer will be handled externally in production.