### PR TITLE
Support multiline text and enter key behavior for Task Items

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -539,6 +539,10 @@ export default function ProjectDetails({ params }: { params: Promise<{ id: strin
 
   const handleInlineItemKeyDown = (e: React.KeyboardEvent, item: TaskItem) => {
     if (e.key === "Enter") {
+      if (item.type === "text") {
+        // Nella textarea, "Enter" va a capo. Non salviamo qui, lo facciamo all'onBlur.
+        return;
+      }
       handleInlineItemUpdate(item, inlineItemValue);
     } else if (e.key === "Escape") {
       setEditingInlineItemId(null);
@@ -1189,18 +1193,29 @@ export default function ProjectDetails({ params }: { params: Promise<{ id: strin
                                   <span className="text-gray-300 italic font-normal">Nessun file</span>
                                 )
                               ) : editingInlineItemId === item.id ? (
-                                <input
-                                  type={item.type === "number" ? "number" : item.type === "date" ? "date" : "text"}
-                                  autoFocus
-                                  value={inlineItemValue}
-                                  onChange={(e) => setInlineItemValue(e.target.value)}
-                                  onBlur={() => handleInlineItemUpdate(item, inlineItemValue)}
-                                  onKeyDown={(e) => handleInlineItemKeyDown(e, item)}
-                                  className="w-full border-2 border-blue-500 rounded-lg px-2 py-1 bg-white text-gray-900 outline-none text-sm"
-                                />
+                                item.type === "text" ? (
+                                  <textarea
+                                    autoFocus
+                                    value={inlineItemValue}
+                                    onChange={(e) => setInlineItemValue(e.target.value)}
+                                    onBlur={() => handleInlineItemUpdate(item, inlineItemValue)}
+                                    onKeyDown={(e) => handleInlineItemKeyDown(e, item)}
+                                    className="w-full border-2 border-blue-500 rounded-lg px-2 py-1 bg-white text-gray-900 outline-none text-sm min-h-[80px]"
+                                  />
+                                ) : (
+                                  <input
+                                    type={item.type === "number" ? "number" : "date"}
+                                    autoFocus
+                                    value={inlineItemValue}
+                                    onChange={(e) => setInlineItemValue(e.target.value)}
+                                    onBlur={() => handleInlineItemUpdate(item, inlineItemValue)}
+                                    onKeyDown={(e) => handleInlineItemKeyDown(e, item)}
+                                    className="w-full border-2 border-blue-500 rounded-lg px-2 py-1 bg-white text-gray-900 outline-none text-sm"
+                                  />
+                                )
                               ) : (
                                 <span
-                                  className="cursor-pointer hover:text-blue-800 transition-colors flex items-center gap-2"
+                                  className="cursor-pointer hover:text-blue-800 transition-colors flex items-center gap-2 whitespace-pre-wrap"
                                   onClick={() => {
                                     setEditingInlineItemId(item.id);
                                     setInlineItemValue(item.value || "");
@@ -1208,7 +1223,7 @@ export default function ProjectDetails({ params }: { params: Promise<{ id: strin
                                   title="Clicca per modificare"
                                 >
                                   {item.value || <span className="text-gray-300 italic font-normal">Aggiungi valore...</span>}
-                                  <Edit2 size={12} className="opacity-0 group-hover/item:opacity-100 transition-opacity" />
+                                  <Edit2 size={12} className="opacity-0 group-hover/item:opacity-100 transition-opacity shrink-0" />
                                 </span>
                               )}
                             </div>
@@ -1582,10 +1597,15 @@ export default function ProjectDetails({ params }: { params: Promise<{ id: strin
                   )}
                   <input type="file" onChange={e => setItemFile(e.target.files?.[0] || null)} className="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 transition" />
                 </div>
+              ) : itemType === "text" ? (
+                <div key="value-input-text">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Valore (opzionale)</label>
+                  <textarea value={itemValue} onChange={e => setItemValue(e.target.value)} className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition" rows={3}></textarea>
+                </div>
               ) : (
                 <div key="value-input">
                   <label className="block text-sm font-medium text-gray-700 mb-1">Valore (opzionale)</label>
-                  <input type={itemType === "number" ? "number" : itemType === "date" ? "date" : "text"} value={itemValue} onChange={e => setItemValue(e.target.value)} className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition" />
+                  <input type={itemType === "number" ? "number" : "date"} value={itemValue} onChange={e => setItemValue(e.target.value)} className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition" />
                 </div>
               )}
 

--- a/src/app/projects/[id]/task/[taskId]/page.tsx
+++ b/src/app/projects/[id]/task/[taskId]/page.tsx
@@ -82,6 +82,9 @@ export default function TaskDetails({ params }: { params: Promise<{ id: string; 
 
   const handleInlineItemKeyDown = (e: React.KeyboardEvent, item: TaskItem) => {
     if (e.key === "Enter") {
+      if (item.type === "text") {
+        return;
+      }
       handleInlineItemUpdate(item, inlineItemValue);
     } else if (e.key === "Escape") {
       setEditingInlineItemId(null);
@@ -300,18 +303,29 @@ export default function TaskDetails({ params }: { params: Promise<{ id: string; 
                           <span></span>
                         )
                       ) : editingInlineItemId === item.id ? (
-                        <input
-                          type={item.type === "number" ? "number" : item.type === "date" ? "date" : "text"}
-                          autoFocus
-                          value={inlineItemValue}
-                          onChange={(e) => setInlineItemValue(e.target.value)}
-                          onBlur={() => handleInlineItemUpdate(item, inlineItemValue)}
-                          onKeyDown={(e) => handleInlineItemKeyDown(e, item)}
-                          className="w-full border-b border-blue-500 outline-none bg-white text-gray-900 px-1 py-0.5 rounded shadow-sm text-sm"
-                        />
+                        item.type === "text" ? (
+                          <textarea
+                            autoFocus
+                            value={inlineItemValue}
+                            onChange={(e) => setInlineItemValue(e.target.value)}
+                            onBlur={() => handleInlineItemUpdate(item, inlineItemValue)}
+                            onKeyDown={(e) => handleInlineItemKeyDown(e, item)}
+                            className="w-full border-b border-blue-500 outline-none bg-white text-gray-900 px-1 py-0.5 rounded shadow-sm text-sm min-h-[80px]"
+                          />
+                        ) : (
+                          <input
+                            type={item.type === "number" ? "number" : "date"}
+                            autoFocus
+                            value={inlineItemValue}
+                            onChange={(e) => setInlineItemValue(e.target.value)}
+                            onBlur={() => handleInlineItemUpdate(item, inlineItemValue)}
+                            onKeyDown={(e) => handleInlineItemKeyDown(e, item)}
+                            className="w-full border-b border-blue-500 outline-none bg-white text-gray-900 px-1 py-0.5 rounded shadow-sm text-sm"
+                          />
+                        )
                       ) : (
                         <span
-                          className="bg-white px-3 py-1.5 rounded-md border border-gray-200 block cursor-pointer hover:border-blue-300 transition-colors"
+                          className="bg-white px-3 py-1.5 rounded-md border border-gray-200 block cursor-pointer hover:border-blue-300 transition-colors whitespace-pre-wrap"
                           onClick={() => {
                             setEditingInlineItemId(item.id);
                             setInlineItemValue(item.value || "");


### PR DESCRIPTION
Questa PR introduce la possibilità di utilizzare e gestire righe a capo per i dettagli (TaskItem) di tipo testo, sia nella modalità di creazione classica (modale) sia nell'editing rapido (inline). Il tasto "Invio" adesso serve per andare a capo nel testo, e il salvataggio inline avviene uscendo dal campo di testo (onBlur). Inoltre, è stata aggiunta la classe `whitespace-pre-wrap` in modo che, al di fuori della modalità di modifica, il testo mantenga e visualizzi correttamente le andate a capo su più righe.

---
*PR created automatically by Jules for task [16790652344960702169](https://jules.google.com/task/16790652344960702169) started by @teoconnect*