### PR TITLE
fix: prevent horizontal scrollbar from cutting off last gantt row

### DIFF
--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -192,6 +192,7 @@ export default function GanttChart({ tasks, onTaskUpdate, onTaskProgressUpdate, 
         }
         .gantt-container {
           overflow-y: hidden !important;
+          padding-bottom: 20px;
         }
         ${colorStyles}
       `}</style>


### PR DESCRIPTION
Added padding-bottom to the .gantt-container to provide clearance for the horizontal scrollbar, resolving a visual bug where the final task was partially hidden.