### PR TITLE
feat: update Gantt chart rows height and layout widths

### DIFF
--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -193,6 +193,7 @@ export default function GanttChart({ tasks, onTaskUpdate, onTaskProgressUpdate, 
         .gantt-container {
           overflow-y: hidden !important;
           padding-bottom: 20px;
+          box-sizing: content-box !important;
         }
         ${colorStyles}
       `}</style>


### PR DESCRIPTION
- Reduced Gantt chart row heights by half in `frappe-gantt` config.
- Updated main layout containers to use `max-w-full` instead of fixed max-widths to expand across the full monitor width.
- Added explicit `padding-bottom` and `box-sizing: content-box` to `.gantt-container` to prevent the horizontal scrollbar from overlapping and clipping the bottom row in the Gantt chart.