### PR TITLE
Fix 404 on dynamic file uploads and secure attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ public/uploads/
 dev.db-journal
 dev_server.log
 *.log
+data/

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -136,9 +136,13 @@ export async function DELETE(
         for (const item of task.items) {
           if (item.value) {
             try {
-              const filename = item.value.split("/").pop();
-              if (filename) {
-                const filepath = path.join(process.cwd(), "public", "uploads", filename);
+              const parts = item.value.split("/");
+              const filename = parts.pop();
+              const projectId = parts.pop();
+              if (filename && projectId) {
+                const safeFilename = path.basename(filename);
+                const safeProjectId = path.basename(projectId);
+                const filepath = path.join(process.cwd(), "data", "uploads", safeProjectId, safeFilename);
                 await unlink(filepath);
               }
             } catch (err) {

--- a/src/app/api/task-items/[id]/route.ts
+++ b/src/app/api/task-items/[id]/route.ts
@@ -9,9 +9,13 @@ import { verifyAuth } from "@/lib/auth";
 async function deleteFileIfAttachment(type: string, value: string | null) {
   if (type === "attachment" && value) {
     try {
-      const filename = value.split("/").pop();
-      if (filename) {
-        const filepath = path.join(process.cwd(), "public", "uploads", filename);
+      const parts = value.split("/");
+      const filename = parts.pop();
+      const projectId = parts.pop();
+      if (filename && projectId) {
+        const safeFilename = path.basename(filename);
+        const safeProjectId = path.basename(projectId);
+        const filepath = path.join(process.cwd(), "data", "uploads", safeProjectId, safeFilename);
         await unlink(filepath);
       }
     } catch (err) {

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -235,9 +235,13 @@ export async function DELETE(
     for (const item of attachmentItems) {
       if (item.value) {
         try {
-          const filename = item.value.split("/").pop();
-          if (filename) {
-            const filepath = path.join(process.cwd(), "public", "uploads", filename);
+          const parts = item.value.split("/");
+          const filename = parts.pop();
+          const projectId = parts.pop();
+          if (filename && projectId) {
+            const safeFilename = path.basename(filename);
+            const safeProjectId = path.basename(projectId);
+            const filepath = path.join(process.cwd(), "data", "uploads", safeProjectId, safeFilename);
             await unlink(filepath);
           }
         } catch (err) {

--- a/src/app/api/uploads/[projectId]/[filename]/route.ts
+++ b/src/app/api/uploads/[projectId]/[filename]/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { verifyAuth } from "@/lib/auth";
+import { readFile } from "fs/promises";
+import path from "path";
+
+// Simple mime type map
+const getMimeType = (filename: string): string => {
+  const ext = filename.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'pdf': return 'application/pdf';
+    case 'png': return 'image/png';
+    case 'jpg':
+    case 'jpeg': return 'image/jpeg';
+    case 'gif': return 'image/gif';
+    case 'webp': return 'image/webp';
+    case 'svg': return 'image/svg+xml';
+    case 'csv': return 'text/csv';
+    case 'txt': return 'text/plain';
+    case 'doc':
+    case 'docx': return 'application/msword';
+    case 'xls':
+    case 'xlsx': return 'application/vnd.ms-excel';
+    default: return 'application/octet-stream';
+  }
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ projectId: string; filename: string }> }
+) {
+  // 1. Verify authentication
+  const cookieStore = await cookies();
+  const token = cookieStore.get("auth-token")?.value;
+
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    await verifyAuth(token);
+  } catch (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const resolvedParams = await params;
+  const { projectId, filename } = resolvedParams;
+
+  if (!projectId || !filename) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+
+  // Prevent directory traversal
+  const safeFilename = path.basename(filename);
+  const safeProjectId = path.basename(projectId);
+
+  // 2. Read the file
+  const filepath = path.join(process.cwd(), "data", "uploads", safeProjectId, safeFilename);
+
+  try {
+    const fileBuffer = await readFile(filepath);
+
+    // 3. Determine MIME type and headers for inline display
+    const mimeType = getMimeType(safeFilename);
+
+    return new NextResponse(fileBuffer, {
+      status: 200,
+      headers: {
+        "Content-Type": mimeType,
+        // Using "inline" attempts to open it in browser instead of downloading
+        "Content-Disposition": `inline; filename="${safeFilename}"`,
+        "Cache-Control": "public, max-age=86400"
+      },
+    });
+  } catch (error) {
+    console.error("Error reading file:", error);
+    return NextResponse.json({ error: "File not found" }, { status: 404 });
+  }
+}

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { writeFile, unlink } from "fs/promises";
+import { writeFile, unlink, mkdir } from "fs/promises";
 import path from "path";
 
 export async function DELETE(request: NextRequest) {
@@ -11,13 +11,20 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "No file specified" }, { status: 400 });
     }
 
-    // Estrarre il nome del file dal percorso (es. /uploads/123-file.txt -> 123-file.txt)
-    const filename = fileUrl.split("/").pop();
-    if (!filename) {
+    // Estrarre id progetto e nome file dal percorso (es. /api/uploads/123/file.txt)
+    const parts = fileUrl.split("/");
+    const filename = parts.pop();
+    const projectId = parts.pop();
+
+    if (!filename || !projectId) {
       return NextResponse.json({ error: "Invalid file path" }, { status: 400 });
     }
 
-    const filepath = path.join(process.cwd(), "public", "uploads", filename);
+    // Sicurezza contro path traversal
+    const safeFilename = path.basename(filename);
+    const safeProjectId = path.basename(projectId);
+
+    const filepath = path.join(process.cwd(), "data", "uploads", safeProjectId, safeFilename);
 
     // Tentativo di eliminazione del file
     await unlink(filepath);
@@ -34,6 +41,7 @@ export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData();
     const file = formData.get("file") as File | null;
+    const projectId = formData.get("projectId") as string | null;
 
     if (!file) {
       return NextResponse.json(
@@ -42,20 +50,34 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (!projectId) {
+      return NextResponse.json(
+        { error: "No project ID specified" },
+        { status: 400 }
+      );
+    }
+
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
 
-    // Save to public/uploads directory
-    const uploadDir = path.join(process.cwd(), "public", "uploads");
+    // Prevent directory traversal
+    const safeProjectId = path.basename(projectId);
+
+    // Save to data/uploads/[projectId] directory
+    const uploadDir = path.join(process.cwd(), "data", "uploads", safeProjectId);
+
+    // Ensure directory exists
+    await mkdir(uploadDir, { recursive: true });
+
     const sanitizedFilename = file.name.replace(/[^a-zA-Z0-9.\-_]/g, '_');
     const filename = `${Date.now()}-${sanitizedFilename}`;
     const filepath = path.join(uploadDir, filename);
 
-    // Write file to public/uploads
+    // Write file to data/uploads/[projectId]
     await writeFile(filepath, buffer);
 
-    // Return the path relative to public directory for URL access
-    return NextResponse.json({ path: `/uploads/${filename}` }, { status: 201 });
+    // Return the path for the API route
+    return NextResponse.json({ path: `/api/uploads/${safeProjectId}/${filename}` }, { status: 201 });
   } catch (error) {
     console.error("Upload error:", error);
     return NextResponse.json(

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -652,6 +652,7 @@ export default function ProjectDetails({ params }: { params: Promise<{ id: strin
       if (itemType === "attachment" && itemFile) {
         const formData = new FormData();
         formData.append("file", itemFile);
+        formData.append("projectId", resolvedParams.id);
         const uploadRes = await fetch("/api/uploads", {
           method: "POST",
           body: formData,


### PR DESCRIPTION
Resolves the 404 issue on dynamic file uploads that required restarting the Next.js container. Uploads are now saved outside the `public` directory into a `data/uploads/[projectId]` structure and served via a dynamic API route. This approach also implements the user's requests to group files by project ID, verify authentication before downloading, and try to display attachments inline in the browser instead of downloading them immediately. All file deletion operations have been updated to support the new path format and safely clean up the filesystem without path traversal vulnerabilities.

---
*PR created automatically by Jules for task [5623411702386364432](https://jules.google.com/task/5623411702386364432) started by @teoconnect*